### PR TITLE
Feature: support entry run

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "SIAB"
-version = "0.2"
+version = "2.1-alpha"
 description = ""
 readme = "README.md"
 authors = [
@@ -19,5 +19,5 @@ dependencies = [
     "addict"
 ]
 
-[tool.setuptools]
-packages = ["SIAB"]
+[project.scripts]
+SIAB_nouvelle = "SIAB.SIAB_nouvelle:main"

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,6 @@ setup(
         "torch_complex",
         "addict"
     ],
-    # If you need to add package data
-    # package_data={'your_package_name': ['data/*.data']},
     zip_safe=False,
     classifiers=[
         # Add classifiers to help others find your project
@@ -26,6 +24,9 @@ setup(
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",  # Change as necessary
         "Operating System :: OS Independent",
+    ],
+    scripts=[
+        "SIAB/SIAB_nouvelle.py",
     ],
    # python_requires='>=3.6', # Specify the min version of Python required
 )


### PR DESCRIPTION
### What's changed
in the past the program can only run with
```
pip install -e .
```
then 
```
python3 SIAB/SIAB_nouvelle.py -i SIAB_INPUT.json
```
, which is very inconvenient. Now user can use
```
pip install .
```
to directly install to pypath/site-packages, then use
```
SIAB_nouvelle -i SIAB_INPUT.json
```
to run orbital generation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated project version to 2.1-alpha, signifying new developments.
	- Introduced a new script, `SIAB_nouvelle`, enhancing usability with a new entry point.
  
- **Bug Fixes**
	- Removed unnecessary comments in the setup configuration for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->