### PR TITLE
Refactor: add explicit dependency on matplotlib

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ authors = [
 ]
 dependencies = [
     "numpy",
+    "matplotlib",
     "scipy<1.10", # required by some functionalities employing the old version simpson integral
     "torch",
     "torch_optimizer",

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         "numpy",
+        "matplotlib",
         "scipy<1.10", # required by some functionalities employing the old version simpson integral
         "torch",
         "torch_optimizer",


### PR DESCRIPTION
Recently I am configuring the setup.py and pyproject.toml to improve its easy-for-use feature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for data visualization through the inclusion of the `matplotlib` library.
- **Chores**
	- Updated dependency lists to include `matplotlib` in both `pyproject.toml` and `setup.py` for enhanced functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->